### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jsdoc-deploy.yml
+++ b/.github/workflows/jsdoc-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy-doc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KucoDEV/StreamIt/security/code-scanning/9](https://github.com/KucoDEV/StreamIt/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily involves checking out code, setting up Node.js, generating documentation, and deploying to an external repository, the `contents: read` permission is sufficient for the `GITHUB_TOKEN`.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the `GITHUB_TOKEN` permissions are explicitly limited across the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
