### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -198,7 +198,12 @@ function handleSearch(e) {
     const all = [...Object.values(appData.films), ...Object.values(appData.series)];
     const res = all.filter(i => i.title.toLowerCase().includes(q));
 
-    document.getElementById('sectionTitle').innerHTML = `Résultats pour "${q}" <span class="text-gray-500 text-sm ml-2">(${res.length})</span>`;
+    const sectionTitleEl = document.getElementById('sectionTitle');
+    sectionTitleEl.textContent = `Résultats pour "${q}" `;
+    const countSpan = document.createElement('span');
+    countSpan.className = 'text-gray-500 text-sm ml-2';
+    countSpan.textContent = `(${res.length})`;
+    sectionTitleEl.appendChild(countSpan);
     renderGrid(res);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/LoupesDEV/StreamIt/security/code-scanning/11](https://github.com/LoupesDEV/StreamIt/security/code-scanning/11)

In general, the problem is that user-controlled input `q` is inserted into HTML via `innerHTML` without proper encoding, allowing an attacker to inject HTML/JS. To fix this, we should ensure that the dynamic, untrusted part (`q`) is treated as text content, not HTML. We can still use `innerHTML` for the static markup if we separate the untrusted text into a text node, or we can switch to using `textContent`/`innerText` for the whole string and build the count with a separate DOM node.

The least intrusive fix that preserves the existing visual output is to stop using a single HTML template that directly interpolates `q`, and instead construct the DOM structure programmatically: set the base text via `textContent` so `q` is safely encoded, and append a `<span>` element for the gray count. Concretely, in `handleSearch` in js/main.js, replace line 201 (the `innerHTML =` line) with code that:
1. Gets `sectionTitle` into a variable.
2. Clears its contents.
3. Creates a text node for `Résultats pour "<q>"` using `textContent`.
4. Creates a `<span>` element, assigns it the existing CSS classes, and sets its `textContent` to `(${res.length})`.
5. Appends both nodes to `sectionTitle`.

This change is fully local to the `handleSearch` function in js/main.js; no new imports or helpers are required. It maintains the same layout and styling because the `<span>` and its classes are preserved, while ensuring that user input is never interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
