### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/js/display.js
+++ b/js/display.js
@@ -86,12 +86,14 @@ export function openDetails(item) {
             renderEpisodes(seasons[seasonKeys[0]], seasonKeys[0]);
 
             seasonSelect.onchange = (e) => {
-                const selectedKey = e.target && typeof e.target.value === 'string' ? e.target.value : null;
-                const selectedSeason = selectedKey && Object.prototype.hasOwnProperty.call(seasons, selectedKey)
-                    ? seasons[selectedKey]
+                const rawValue = e.target && typeof e.target.value === 'string' ? e.target.value : null;
+                const selectedKey = rawValue && Object.prototype.hasOwnProperty.call(seasons, rawValue)
+                    ? rawValue
                     : null;
+                const selectedSeason = selectedKey ? seasons[selectedKey] : null;
                 if (selectedSeason) {
-                    renderEpisodes(selectedSeason, selectedKey);
+                    const safeSeasonId = String(selectedKey);
+                    renderEpisodes(selectedSeason, safeSeasonId);
                 }
             };
         } else {
@@ -133,13 +135,17 @@ function renderEpisodes(episodes, seasonNum) {
         ];
     }
 
+    const safeSeasonNum = typeof seasonNum === 'string'
+        ? seasonNum.replace(/[^0-9]/g, '') || '1'
+        : String(Number.isFinite(seasonNum) ? seasonNum : 1);
+
     if (episodes.length > 0) activeVideoSrc = episodes[0].video;
 
     episodes.forEach((ep, idx) => {
         const row = document.createElement('div');
         row.className = "episode-item flex flex-col md:flex-row items-center gap-6 p-4 rounded-2xl cursor-pointer transition-all border border-transparent hover:border-white/5 hover:bg-white/[0.02] group bg-[#0a0a0a]";
 
-        const fallbackThumb = `https://placehold.co/300x200/333/666?text=S${seasonNum}-EP${idx + 1}`;
+        const fallbackThumb = `https://placehold.co/300x200/333/666?text=S${safeSeasonNum}-EP${idx + 1}`;
         const thumbUrl = activeDetailItem ? activeDetailItem.banner : fallbackThumb;
 
         // Left container: index + thumbnail


### PR DESCRIPTION
Potential fix for [https://github.com/LoupesDEV/StreamIt/security/code-scanning/13](https://github.com/LoupesDEV/StreamIt/security/code-scanning/13)

In general, to fix this kind of problem you must prevent untrusted DOM-derived strings from being interpreted in a context where they can be treated as code or markup. Here, that means preventing an untrusted `seasonNum` from directly influencing a URL assigned to `img.src`. The best approach without changing existing behavior is to (1) ensure the season key read from the `<select>` is validated/normalized against an expected set, and (2) construct `fallbackThumb` using this safe, validated value instead of the raw `seasonNum`.

Concretely, in `setupHero`, inside the `seasonSelect.onchange` handler, we will normalize `selectedKey` to a strictly allowed form: check that it exists as a property in `seasons` (we already do), then convert it to a string containing only digits (or otherwise a safe canonical key). This normalized value is what we pass as `seasonNum` to `renderEpisodes`. Then, in `renderEpisodes`, we will use a local, sanitized `safeSeasonNum` derived from `seasonNum` when building `fallbackThumb`:

```js
const safeSeasonNum = typeof seasonNum === 'string'
    ? seasonNum.replace(/[^0-9]/g, '') || '1'
    : String(Number.isFinite(seasonNum) ? seasonNum : 1);
const fallbackThumb = `https://placehold.co/300x200/333/666?text=S${safeSeasonNum}-EP${idx + 1}`;
```

This ensures any characters that could meaningfully alter the URL scheme (like `:`, `/`, `?`, etc.) are removed, and we always end up with a benign numeric text segment. The rest of the code remains unchanged; we still display “Saison {key}” and still select the correct `seasons[key]` object, preserving functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
