### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -260,7 +260,6 @@ function handleSearch(e) {
 
     const titleEl = document.getElementById('titleText');
     if (titleEl) {
-        // Safely update the title text and count without using innerHTML with untrusted input
         titleEl.textContent = `Résultats pour "${q}" `;
         let countSpan = titleEl.querySelector('.text-gray-500.text-sm.ml-2');
         if (!countSpan) {
@@ -272,7 +271,6 @@ function handleSearch(e) {
     } else {
         const sectionTitle = document.getElementById('sectionTitle');
         if (sectionTitle) {
-            // Rebuild the section title structure using DOM APIs to avoid interpreting q as HTML
             while (sectionTitle.firstChild) {
                 sectionTitle.removeChild(sectionTitle.firstChild);
             }

--- a/js/main.js
+++ b/js/main.js
@@ -260,12 +260,32 @@ function handleSearch(e) {
 
     const titleEl = document.getElementById('titleText');
     if (titleEl) {
-        titleEl.innerHTML = `Résultats pour "${q}" <span class="text-gray-500 text-sm ml-2">(${res.length})</span>`;
+        // Safely update the title text and count without using innerHTML with untrusted input
+        titleEl.textContent = `Résultats pour "${q}" `;
+        let countSpan = titleEl.querySelector('.text-gray-500.text-sm.ml-2');
+        if (!countSpan) {
+            countSpan = document.createElement('span');
+            countSpan.className = 'text-gray-500 text-sm ml-2';
+            titleEl.appendChild(countSpan);
+        }
+        countSpan.textContent = `(${res.length})`;
     } else {
         const sectionTitle = document.getElementById('sectionTitle');
         if (sectionTitle) {
-            sectionTitle.innerHTML = `<span class="w-1 h-8 bg-red-600 rounded-full shadow-[0_0_15px_#dc2626]"></span>
-                <span id="titleText" class="tracking-tight">Résultats pour "${q}" (${res.length})</span>`;
+            // Rebuild the section title structure using DOM APIs to avoid interpreting q as HTML
+            while (sectionTitle.firstChild) {
+                sectionTitle.removeChild(sectionTitle.firstChild);
+            }
+
+            const accentSpan = document.createElement('span');
+            accentSpan.className = 'w-1 h-8 bg-red-600 rounded-full shadow-[0_0_15px_#dc2626]';
+            sectionTitle.appendChild(accentSpan);
+
+            const titleTextSpan = document.createElement('span');
+            titleTextSpan.id = 'titleText';
+            titleTextSpan.className = 'tracking-tight';
+            titleTextSpan.textContent = `Résultats pour "${q}" (${res.length})`;
+            sectionTitle.appendChild(titleTextSpan);
         }
     }
     renderGrid(res);


### PR DESCRIPTION
Potential fix for [https://github.com/LoupesDEV/StreamIt/security/code-scanning/15](https://github.com/LoupesDEV/StreamIt/security/code-scanning/15)

In general, the fix is to ensure that untrusted text (`q`) is never directly concatenated into HTML strings that are assigned to `.innerHTML`. Instead, build the DOM structure with `textContent`/`innerText` or explicitly escape user-controlled text before using `innerHTML`.

The best fix here without changing functionality is:
- Keep the existing HTML structure (spans, classes, etc.).
- Populate the dynamic parts (`q` and `res.length`) via `textContent` on dedicated nodes.
- Avoid interpolating `q` inside an HTML template string passed to `innerHTML`.

Concretely:
1. For the branch where `titleEl` exists (line 261+), replace the `innerHTML` assignment with:
   - Set `titleEl.textContent` to `Résultats pour "` + q + `" `.
   - Create or reuse a child `<span>` for the count `(res.length)` with the appropriate classes and set its `textContent` to `(${res.length})`.
2. For the branch where `sectionTitle` exists but `titleText` doesn’t (lines 265–269), instead of using a template string with `innerHTML`, clear `sectionTitle` and:
   - Create a decorative span (`<span class="w-1 ...">`) and append it.
   - Create a `<span id="titleText" class="tracking-tight">` and set its `textContent` to `Résultats pour "${q}" (${res.length})`.
   This way, `q` is only ever inserted via `textContent`.

No new imports or helper functions are needed; all changes are within `handleSearch` in `js/main.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
